### PR TITLE
Remove duplicate text block

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -186,16 +186,6 @@ These retries and timeouts relate to validating the Administrator password
 once AWS provides the credentials via the AWS API.
 
 
-Windows Deploy Timeouts
-=======================
-For Windows instances, it may take longer than normal for the instance to be
-ready.  In these circumstances, the provider configuration can be configured
-with a ``win_deploy_auth_retries`` and/or a ``win_deploy_auth_retry_delay``
-setting, which default to 10 retries and a one second delay between retries.
-These retries and timeouts relate to validating the Administrator password
-once AWS provides the credentials via the AWS API.
-
-
 Key Pairs
 =========
 In order to create an instance with Salt installed and configured, a key pair


### PR DESCRIPTION
There were two identical blocks concerning Windows Deploy Timeouts. This pull request removes the extra block of text.